### PR TITLE
fix (doc): 根据docker doc修改docker部署下的cooq http配置的部分文档

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -56,7 +56,7 @@ Running on https://127.0.0.1:8080 (CTRL + C to quit)
 ```
 
 ::: tip 提示
-**这里的 `127.0.0.1:8080` 对应 `nonebot.run()` 中传入的 `host` 和 `port`**，如果在 `nonebot.run()` 中传入的 `host` 是 `0.0.0.0`，则插件的配置中需使用任意一个能够访问到 NoneBot 所在环境的 IP，**不要直接填 `0.0.0.0`**。特别地，如果你的 酷Q 运行在 Docker 容器中，NoneBot 运行在宿主机中，则默认情况下这里需使用 `172.17.0.1`（不同机器有可能不同，如果为 `mac osx` 系统或者`windows` 系统，可以考虑使用特殊 `Dns name`: `host.docker.internal`，具体解释详见 Docker 文档的 [Use cases and workarounds > I WANT TO CONNECT FROM A CONTAINER TO A SERVICE ON THE HOST](https://docs.docker.com/docker-for-mac/networking/#/known-limitations-use-cases-and-workarounds)）。
+**这里的 `127.0.0.1:8080` 对应 `nonebot.run()` 中传入的 `host` 和 `port`**，如果在 `nonebot.run()` 中传入的 `host` 是 `0.0.0.0`，则插件的配置中需使用任意一个能够访问到 NoneBot 所在环境的 IP，**不要直接填 `0.0.0.0`**。特别地，如果你的 酷Q 运行在 Docker 容器中，NoneBot 运行在宿主机中，则默认情况下这里需使用 `172.17.0.1`（不同机器有可能不同，如果是 macOS 系统或者 Windows 系统，可以考虑使用 `host.docker.internal`，具体解释详见 Docker 文档的 [Use cases and workarounds](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds) 的「I WANT TO CONNECT FROM A CONTAINER TO A SERVICE ON THE HOST」小标题）。
 :::
 
 ::: warning 注意

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -56,7 +56,7 @@ Running on https://127.0.0.1:8080 (CTRL + C to quit)
 ```
 
 ::: tip 提示
-**这里的 `127.0.0.1:8080` 对应 `nonebot.run()` 中传入的 `host` 和 `port`**，如果在 `nonebot.run()` 中传入的 `host` 是 `0.0.0.0`，则插件的配置中需使用任意一个能够访问到 NoneBot 所在环境的 IP，**不要直接填 `0.0.0.0`**。特别地，如果你的 酷Q 运行在 Docker 容器中，NoneBot 运行在宿主机中，则默认情况下这里需使用 `172.17.0.1`（不同机器有可能不同，需使用 `docker inspect bridge` 查看，具体见 Docker 文档的 [Configure networking](https://docs.docker.com/network/)）。
+**这里的 `127.0.0.1:8080` 对应 `nonebot.run()` 中传入的 `host` 和 `port`**，如果在 `nonebot.run()` 中传入的 `host` 是 `0.0.0.0`，则插件的配置中需使用任意一个能够访问到 NoneBot 所在环境的 IP，**不要直接填 `0.0.0.0`**。特别地，如果你的 酷Q 运行在 Docker 容器中，NoneBot 运行在宿主机中，则默认情况下这里需使用 `172.17.0.1`（不同机器有可能不同，如果为 `mac osx` 系统或者`windows` 系统，可以考虑使用特殊 `Dns name`: `host.docker.internal`，具体解释详见 Docker 文档的 [Use cases and workarounds > I WANT TO CONNECT FROM A CONTAINER TO A SERVICE ON THE HOST](https://docs.docker.com/docker-for-mac/networking/#/known-limitations-use-cases-and-workarounds)）。
 :::
 
 ::: warning 注意


### PR DESCRIPTION
由于目前文档中的配置 `172.17.0.1` 在 `mac` 机器上会出现 `connect refused` 问题，参考了 docker doc 后进行的修改。[源文档](https://docs.docker.com/docker-for-mac/networking/#/known-limitations-use-cases-and-workarounds)