### PR TITLE
修复 @on_natural_language 装饰器未检查 keywords 参数类型可能导致匹配错误的问题

### DIFF
--- a/nonebot/natural_language.py
+++ b/nonebot/natural_language.py
@@ -42,6 +42,9 @@ def on_natural_language(keywords: Union[Optional[Iterable], Callable] = None,
     :param allow_empty_message: handle empty messages
     """
 
+    if type(keywords) is str:
+        keywords = (keywords, )
+
     def deco(func: Callable) -> Callable:
         nl_processor = NLProcessor(func=func, keywords=keywords,
                                    permission=permission,


### PR DESCRIPTION
示例：在聊天内容包含*ABC*时触发。

`@on_natural_language(keywords=('ABC',), only_to_me=False)`

这样的代码可以正常工作。

但如果少打一个逗号变成这样

`@on_natural_language(keywords=('ABC'), only_to_me=False)`

功能会变为：在聊天内容包含**A或B或C**时触发。

此 PR 修复上述问题。
